### PR TITLE
Update to build against go1.14

### DIFF
--- a/notifier_darwin.go
+++ b/notifier_darwin.go
@@ -5,7 +5,7 @@ package notifier
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa -sectcreate __TEXT __info_plist Info.plist
+#cgo LDFLAGS: -framework Cocoa -Wl,-sectcreate,__TEXT,__info_plist,Info.plist
 #import <Cocoa/Cocoa.h>
 extern CFStringRef deliverNotification(CFStringRef title, CFStringRef subtitle, CFStringRef message, CFStringRef appIconURLString, CFArrayRef actions, CFStringRef groupID, CFStringRef bundleID, NSTimeInterval timeout, bool debug);
 */

--- a/notifier_darwin.go
+++ b/notifier_darwin.go
@@ -54,8 +54,8 @@ func (n darwinNotifier) DeliverNotification(notification Notification) error {
 	actionsRef := StringsToCFArray(notification.Actions)
 	defer Release(C.CFTypeRef(actionsRef))
 
-	C.deliverNotification(titleRef, nil, messageRef, appIconURLStringRef, actionsRef,
-		bundleIDRef, nil, C.NSTimeInterval(notification.Timeout), false)
+	C.deliverNotification(titleRef, 0, messageRef, appIconURLStringRef, actionsRef,
+		bundleIDRef, 0, C.NSTimeInterval(notification.Timeout), false)
 
 	return nil
 }


### PR DESCRIPTION
Fix build errors on current versions of macOS and Go due to Cgo changes in Go 1.10: https://tip.golang.org/doc/go1.10#cgo.

Issues with:

* The `-sectcreate` linker flag
* Using `nil` with CoreFoundation ref types
* `unsafe.Pointer` casts

I've added more detailed information in the commit messages.
